### PR TITLE
Connection strings are now working for Dev and Prod regardless of the usage of Docker or the absense of it.

### DIFF
--- a/BX.Backend/Program.cs
+++ b/BX.Backend/Program.cs
@@ -13,11 +13,13 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 #region SQL Server Connection
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-//if (connectionString.IsNullOrEmpty())
-//{
-//    connectionString = builder.Configuration.GetConnectionString("userSecretDB"); //Run this string as your secret in the local terminal
-//}
+//Run this string as your secret in the local terminal
+//dotnet user-secrets set "ConnectionStrings:userSecretDB" "<connection-string>"
+var connectionString = builder.Configuration.GetConnectionString("userSecretDB");
+if (connectionString.IsNullOrEmpty())
+{
+    connectionString = builder.Configuration.GetConnectionString("DefaultConnection"); 
+}
 
 builder.Services.AddDbContext<BuildXpertContext>(options =>
 {

--- a/BX.Frontend/Program.cs
+++ b/BX.Frontend/Program.cs
@@ -29,13 +29,13 @@ builder.Services.AddScoped<AuthenticationStateProvider, IdentityRevalidatingAuth
 
 
 #region SQL Server Connection
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-//if (connectionString.IsNullOrEmpty())
-//{
-//    connectionString = builder.Configuration.GetConnectionString("userSecretDB"); //Run this string as your secret in the local terminal
-//}
-
-//System.Threading.Thread.Sleep(50);
+//Run this string as your secret in the local terminal
+//dotnet user-secrets set "ConnectionStrings:userSecretDB" "<connection-string>"
+var connectionString = builder.Configuration.GetConnectionString("userSecretDB");
+if (connectionString.IsNullOrEmpty())
+{
+    connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+}
 
 builder.Services.AddDbContext<BuildXpertContext>(options =>
 {


### PR DESCRIPTION
To be able to use the application without docker, please run these commands

cd .\BX.Backend\
dotnet user-secrets set "ConnectionStrings:userSecretDB" "<connection_string>"
dotnet user-secrets list
cd..

cd .\BX.Frontend\
dotnet user-secrets set "ConnectionStrings:userSecretDB" "<connection_string>"
dotnet user-secrets list

Please refer to this in the Required Commands internal file.